### PR TITLE
Add a "SetContent" function

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ tex.init({
 // ES6
 import tex from 'tex'
 // or
-import { exec, init, destroy, getContent } from 'tex'
+import { exec, init, destroy, getContent, setContent } from 'tex'
 ```
 
 ### Parameters
@@ -88,7 +88,10 @@ import { exec, init, destroy, getContent } from 'tex'
 ```javascript
 tex.getContent(document.getElementById("editor"));
 ```
-
+### Set Content
+```javascript
+tex.setContent(document.getElementById("editor"),"<p>Text in <strong>HTML</strong> format")
+```
 ### Exec
 ```javascript
 // Execute a document command.

--- a/examples/index.html
+++ b/examples/index.html
@@ -12,7 +12,7 @@
     <div id="editor1">Hello</div>
     <textarea id="editor2">Hello world!</textarea>
     <div id="editor3">Hello world!</div>
-
+    <div id="editor4"></div>
     <script>
         const tex = window.tex;
         tex.init({
@@ -40,6 +40,19 @@
                 console.log(content);
             }
         });
+        tex.init({
+            element: document.getElementById("editor4"),
+            buttons: ['bold', 'italic', 'underline', 'strikethrough', 'textColor', 'heading1', 'heading2', 'paragraph', 'removeFormat', 'quote', 'olist', 'ulist', 'code', 'line', 'link', 'image', 'html'],
+            defaultParagraphSeparator: 'p',
+            styleWithCSS: false,
+            theme: 'dark',
+            onChange: (content) => {
+                console.log(content);
+            }
+        });
+        tex.setContent(document.getElementById("editor4"),
+        "<h1>Hello there!</h1><p>This text was added using the <code>setContent</code> method.</p>" +
+        "<p>It allows you to set the content of the editor programmatically.</p>");
 
         // tex.destroy(document.getElementById("editor"));
     </script>

--- a/src/tex.js
+++ b/src/tex.js
@@ -259,6 +259,15 @@ var getContent = el => {
   const content = element.querySelector('.tex-content')
   return content.innerHTML
 }
+var setContent = (el, content) => {
+  const element = document.querySelector(`[tex-id="${el.id}"]`)
+  const contentElement = element.querySelector('.tex-content')
+  contentElement.innerHTML = content
+  element.querySelector('.htmlContent').value = content
+  el.value = content
+}
+
+
 
 var init = settings => {
   var theme = settings.theme || 'light'
@@ -383,12 +392,13 @@ htmlContent.oninput = ({ target: { firstChild } }) => {
 return settings.element
 }
 
-var tex = { exec: exec, init: init, destroy: destroy, getContent: getContent }
+var tex = { exec: exec, init: init, destroy: destroy, getContent: getContent, setContent: setContent }
 
 exports.exec = exec
 exports.init = init
 exports.destroy = destroy
 exports.getContent = getContent
+exports.setContent = setContent
 exports['default'] = tex
 
 Object.defineProperty(exports, '__esModule', { value: true })


### PR DESCRIPTION
This pull request introduces a new `setContent` method to the `tex` library, allowing users to programmatically set the content of the editor. It updates the core library, documentation, and examples to reflect this new functionality.

### Core Library Changes:
* Added a `setContent` method to the `tex` object, allowing users to set the content of the editor via JavaScript. This method updates both the visible editor content and the underlying HTML content. (`src/tex.js`, [[1]](diffhunk://#diff-71389b18bc4b9981075d8a27aeb2a6b0ddc5220b130c29025dba4fc3d82f1e2dR262-R270) [[2]](diffhunk://#diff-71389b18bc4b9981075d8a27aeb2a6b0ddc5220b130c29025dba4fc3d82f1e2dL386-R401)

### Documentation Updates:
* Updated the `README.md` to include `setContent` in the list of exported methods and added an example usage of `setContent` under a new "Set Content" section. (`README.md`, [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L74-R74) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L91-R94)

### Example Updates:
* Modified `examples/index.html` by adding a new editor instance (`editor4`) and demonstrating the use of the `setContent` method to populate it with programmatically defined content. (`examples/index.html`, [[1]](diffhunk://#diff-a11faa5810ac713931e63304028150455c6e34d4aef559c6ab0b6c7219153ffaL15-R15) [[2]](diffhunk://#diff-a11faa5810ac713931e63304028150455c6e34d4aef559c6ab0b6c7219153ffaR43-R55)