### PR TITLE
Fire onChange on setContent + docs fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ tex.getContent(document.getElementById("editor"));
 ```
 ### Set Content
 ```javascript
-tex.setContent(document.getElementById("editor"),"<p>Text in <strong>HTML</strong> format")
+tex.setContent(document.getElementById("editor"), "<p>Text in <strong>HTML</strong> format</p>")
 ```
 ### Exec
 ```javascript

--- a/src/tex.js
+++ b/src/tex.js
@@ -265,9 +265,8 @@ var setContent = (el, content) => {
   contentElement.innerHTML = content
   element.querySelector('.htmlContent').value = content
   el.value = content
+  if (element.texOnChange) element.texOnChange(content)
 }
-
-
 
 var init = settings => {
   var theme = settings.theme || 'light'
@@ -276,6 +275,7 @@ var init = settings => {
   editorContainer.className = 'tex-container'
   editorContainer.classList.add(`theme-${theme}`)
   editorContainer.setAttribute("tex-id", settings.element.id)
+  editorContainer.texOnChange = settings.onChange
   var actionbar = createElement('div')
   actionbar.className = 'tex-actionbar'
   appendChild(editorContainer, actionbar)


### PR DESCRIPTION
Follow-up to #16.

- `setContent` now fires the `onChange` callback so listeners are notified of programmatic changes (the handler is stored on the editor container in `init`).
- Removed stray blank lines after `setContent`.
- README: closed the `<p>` tag in the `setContent` example.

🤖 Generated with [Claude Code](https://claude.com/claude-code)