### PR TITLE
Add exports map for cleaner CSS import (1.0.1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ npm install tex-editor
 ```javascript
 import tex from 'tex-editor'
 // don't forget the stylesheet:
-import 'tex-editor/src/tex.css'
+import 'tex-editor/tex.css'
 ```
 
 Then add HTML elements where you want to display the text editors:
@@ -126,7 +126,7 @@ using a `ref`, and tear it down in the cleanup function.
 ```jsx
 import { useEffect, useRef } from 'react'
 import tex from 'tex-editor'
-import 'tex-editor/src/tex.css'
+import 'tex-editor/tex.css'
 
 export default function TexEditor({ value = '', onChange }) {
   const ref = useRef(null)

--- a/package.json
+++ b/package.json
@@ -1,11 +1,18 @@
 {
   "name": "tex-editor",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Ultra-lightweight WYSIWYG rich text editor in pure JavaScript, no dependencies. Works with both <textarea> and <div> elements.",
   "main": "src/tex.js",
   "unpkg": "src/tex.js",
   "jsdelivr": "src/tex.js",
   "style": "src/tex.css",
+  "exports": {
+    ".": "./src/tex.js",
+    "./tex.css": "./src/tex.css",
+    "./tex.js": "./src/tex.js",
+    "./src/*": "./src/*",
+    "./package.json": "./package.json"
+  },
   "files": [
     "src",
     "README.md",


### PR DESCRIPTION
Adds an `exports` map so the stylesheet can be imported with a cleaner path:

```js
import 'tex-editor/tex.css'   // instead of tex-editor/src/tex.css
```

The old `tex-editor/src/tex.css` path still resolves (backward compatible). Bumps version to 1.0.1, which the publish workflow will ship to npm on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)