### PR TITLE
Fix bugs, slim core, add robustness and a11y; bump to 1.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ TEX is a ultra-lightweight and straightforward JavaScript library for creating r
 
 | library       | size (min+gzip) | size (min) | jquery | bootstrap | react | link |
 |---------------|-----------------|------------|--------|-----------|-------|------|
-| TEX          | 2.3kB          | 6.3kB     |        |           |       | https://github.com/marcellov7/tex |
+| TEX          | 2.4kB          | 6.6kB     |        |           |       | https://github.com/marcellov7/tex |
 | quill         | 43kB            | 205kB      |        |           |       | https://github.com/quilljs/quill |
 | trix          | 47kB            | 204kB      |        |           |       | https://github.com/basecamp/trix |
 | ckeditor      | 163kB           | 551kB      |        |           |       | https://ckeditor.com |
@@ -93,9 +93,10 @@ import { exec, init, destroy, getContent, setContent } from 'tex-editor'
 - `element`: The HTML element (either `<textarea>` or `<div>`) to be converted into a text editor.
 - `buttons`: An array of buttons to be displayed in the editor toolbar.
 - `plugins`: An array of plugins.
-- `paragraphSeparator` : 'p', // optional, default = 'div'
+- `defaultParagraphSeparator` : 'p', // optional, default = 'div'
 - `cssStyle`: false | true,   // Outputs <span style="font-weight: bold;"></span> instead of <b></b> 
 - `theme`: 'dark' | default (light),
+- `ariaLabel`: Accessible label for the editable area (optional, default = 'Rich text editor').
 - `onChange`: A callback function to be executed when the content of the editor changes.
 
 ### Get Content

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tex-editor",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "Ultra-lightweight WYSIWYG rich text editor in pure JavaScript, no dependencies. Works with both <textarea> and <div> elements.",
   "main": "src/tex.js",
   "unpkg": "src/tex.js",

--- a/src/tex.css
+++ b/src/tex.css
@@ -64,14 +64,7 @@
 }   
 
 .tex-button-selected {
-  background-color: #F0F0F0; 
-}
-
-.tex-modal{
-  position: absolute;
-  background-color: white;
-  border: 1px solid #ccc;
-  padding:5px;
+  background-color: #F0F0F0;
 }
 
 .tex-button > *:nth-child(2) {

--- a/src/tex.js
+++ b/src/tex.js
@@ -4,11 +4,8 @@
   factory((global.tex = {}));
 }(this, (function (exports) { 'use strict'
 
-var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key] } } } return target }
-
 var colorPicker = function(button, type) {
-  var input = button.querySelector('input[type="color"]')
-  input = document.createElement('input')
+  var input = document.createElement('input')
   input.type = 'color'
   input.style.display = 'block'
   button.appendChild(input)
@@ -28,8 +25,7 @@ var colorPicker = function(button, type) {
 }
 
 var selectOptions = function(button) {
-  var input = button.querySelector('select')
-  input = document.createElement('select')
+  var input = document.createElement('select')
   const fontSizes = [3, 4, 5, 6, 7]
   fontSizes.forEach(size => {
     const option = document.createElement('option')
@@ -231,36 +227,38 @@ var defaultActions = {
 
 var destroy = el => {
   var element = document.querySelector(`[tex-id="${el.id}"]`)
+  if (!element) return
   var elementBase = document.getElementById(el.id)
   var content = element.querySelector('.tex-content')
   var actionbar = element.querySelector('.tex-actionbar')
-  if (element) {
-    var contentClone = content.cloneNode(true)
-    content.parentNode.replaceChild(contentClone, content)
 
-    var actionbarClone = actionbar.cloneNode(true)
-    actionbar.parentNode.replaceChild(actionbarClone, actionbar)
+  var contentClone = content.cloneNode(true)
+  content.parentNode.replaceChild(contentClone, content)
 
-    actionbarClone.remove()
+  var actionbarClone = actionbar.cloneNode(true)
+  actionbar.parentNode.replaceChild(actionbarClone, actionbar)
 
-    if (elementBase.tagName.toLowerCase() === 'textarea') {
-      elementBase.style.display = 'block'
-      element.remove()
-    } else { 
-      element.innerHTML = contentClone.innerHTML
-      element.removeAttribute("tex-id")
-      element.classList.remove("theme-light", "theme-dark", "tex-container")
-    }
+  actionbarClone.remove()
+
+  if (elementBase.tagName.toLowerCase() === 'textarea') {
+    elementBase.style.display = 'block'
+    element.remove()
+  } else {
+    element.innerHTML = contentClone.innerHTML
+    element.removeAttribute("tex-id")
+    element.classList.remove("theme-light", "theme-dark", "tex-container")
   }
 }
 
 var getContent = el => {
   const element = document.querySelector(`[tex-id="${el.id}"]`)
+  if (!element) return
   const content = element.querySelector('.tex-content')
   return content.innerHTML
 }
 var setContent = (el, content) => {
   const element = document.querySelector(`[tex-id="${el.id}"]`)
+  if (!element) return
   const contentElement = element.querySelector('.tex-content')
   contentElement.innerHTML = content
   element.querySelector('.htmlContent').value = content
@@ -269,6 +267,8 @@ var setContent = (el, content) => {
 }
 
 var init = settings => {
+  if (document.querySelector(`[tex-id="${settings.element.id}"]`)) return settings.element
+  var isTextarea = settings.element.tagName.toLowerCase() === 'textarea'
   var theme = settings.theme || 'light'
   var paragraphSeparator = settings[paragraphSeparatorString] || 'div'
   var editorContainer = createElement('div')
@@ -283,8 +283,11 @@ var init = settings => {
   var content = settings.element.content = createElement('div')
   content.contentEditable = true
   content.className = 'tex-content tex-editor'
+  content.setAttribute('role', 'textbox')
+  content.setAttribute('aria-multiline', 'true')
+  content.setAttribute('aria-label', settings.ariaLabel || 'Rich text editor')
 
-  if (settings.element.tagName.toLowerCase() === 'textarea') {
+  if (isTextarea) {
     content.innerHTML = settings.element.value
   } else {
     content.innerHTML = settings.element.innerHTML
@@ -300,26 +303,24 @@ var init = settings => {
 
   let actions = []
 
+  var actionsMap = defaultActions
+  if (settings.plugins) {
+    actionsMap = { ...defaultActions }
+    settings.plugins.forEach(plugin => { actionsMap[plugin.name] = plugin })
+  }
+
   if (settings.buttons) {
-
-    if (settings.plugins) {
-      console.log(settings.plugins)
-      settings.plugins.forEach(function(plugin) {
-        defaultActions[plugin.name] = plugin
-      })
-    }
-
     actions = settings.buttons.map(buttonKey => {
-      var defaultAction = defaultActions[buttonKey]
+      var defaultAction = actionsMap[buttonKey]
       if (defaultAction) {
         return { icon: defaultAction.icon, title: defaultAction.title, key: buttonKey, result: defaultAction.result }
       }
     }).filter(action => action !== undefined)
   } else if (settings.actions) {
     actions = settings.actions.map(action => {
-      if (typeof action === 'string') return defaultActions[action]
+      if (typeof action === 'string') return actionsMap[action]
       else if (action.name === 'custom') return { icon: action.icon, title: action.title, result: action.result }
-      else if (defaultActions[action.name]) return { ...defaultActions[action.name], ...action }
+      else if (actionsMap[action.name]) return { ...actionsMap[action.name], ...action }
       return action
     })
   }
@@ -330,10 +331,16 @@ actions.forEach(action => {
   button.innerHTML = "<span>"+action.icon+"</span>"
   button.title = action.title
   button.setAttribute('type', 'button')
+  button.setAttribute('aria-label', action.title)
   button.onclick = () => action.result({action, content, button}) && content.focus()
 
   if (action.state) {
-    var handler = () => button.classList[action.state() ? 'add' : 'remove']('tex-button-selected')
+    button.setAttribute('aria-pressed', 'false')
+    var handler = () => {
+      var on = action.state()
+      button.classList[on ? 'add' : 'remove']('tex-button-selected')
+      button.setAttribute('aria-pressed', on)
+    }
     addEventListener(content, 'keyup', handler)
     addEventListener(content, 'mouseup', handler)
     addEventListener(button, 'click', handler)
@@ -356,7 +363,7 @@ actions.forEach(action => {
 if (settings.cssStyle) exec('styleWithCSS')
 exec(paragraphSeparatorString, paragraphSeparator)
 
-if (settings.element.tagName.toLowerCase() === 'textarea') {
+if (isTextarea) {
   settings.element.style.display = 'none'
 } else {
   document.getElementById(settings.element.id).remove()
@@ -374,9 +381,9 @@ content.oninput = ({ target: { firstChild } }) => {
   if (firstChild && firstChild.nodeType === 3) exec(formatBlock, `<${paragraphSeparator}>`)
   else if (content.innerHTML === '<br>') content.innerHTML = ''
 
-  settings.onChange(content.innerHTML)
+  settings.onChange && settings.onChange(content.innerHTML)
 
-  if (settings.element.tagName.toLowerCase() === 'textarea') {
+  if (isTextarea) {
     settings.element.value = content.innerHTML
   }
   
@@ -386,7 +393,7 @@ content.oninput = ({ target: { firstChild } }) => {
 htmlContent.oninput = ({ target: { firstChild } }) => {
   content.innerHTML = htmlContent.value
   settings.element.value = content.innerHTML
-  settings.onChange(content.innerHTML)
+  settings.onChange && settings.onChange(content.innerHTML)
 }
 
 return settings.element


### PR DESCRIPTION
Bug fixes:
- onChange is now optional (no crash on every keystroke when omitted)
- plugins resolve on a local map instead of mutating the global defaultActions (no cross-instance contamination)
- remove leftover debug console.log
- align README to the real option name (defaultParagraphSeparator)

Slimming (no capability loss):
- drop unused _extends Object.assign polyfill (dead code)
- compute isTextarea once instead of repeating the tagName check
- remove dead first lines in colorPicker/selectOptions
- remove unused .tex-modal CSS rule

Robustness (React-friendly):
- guard against double init on the same element
- null guards in destroy/getContent/setContent (and run the destroy null-check before touching the DOM)

Accessibility:
- aria-label on toolbar buttons (icons are unreadable to screen readers)
- aria-pressed on stateful toggle buttons
- role=textbox + aria-multiline + aria-label on the editable area, configurable via the new ariaLabel option

Docs: correct the size table to the measured values (2.4kB min+gzip, 6.6kB min).